### PR TITLE
Add PEP723 compliance

### DIFF
--- a/ratefile_read.py
+++ b/ratefile_read.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pydantic",
+
+# ]
+# ///
+
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from pathlib import Path


### PR DESCRIPTION
Just adding the header for PEP723 compliant tools to work. Script is executable most easily with [uv](https://docs.astral.sh/uv/) by running `uv run ratefile_read.py`