### PR TITLE
PEP723 and click cli interface for ratefile path

### DIFF
--- a/ratefile_read.py
+++ b/ratefile_read.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pydantic",
+#   "click",
+# ]
+# ///
+
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from pathlib import Path
@@ -331,6 +339,18 @@ def read_ratefile(file_path: str) -> RateFile:
     return RateFile(header=header, surcharges=surcharges, price_plan=price_plan, npa_groups=npa_groups, nxx_tables=nxx_tables)
 
 
-if __name__ == '__main__':
-    parse = read_ratefile('elcotel-playground/stock.R94')
+@click.command()
+@click.option(
+    '--file', '-f', default='elcotel-playground/stock.R94', help='Path to the rate file'
+)
+def main(file):
+    try:
+        parse = read_ratefile(file)
+    except FileNotFoundError:
+        print(f'File not found: {file}')
+        sys.exit(1)
     print(parse)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adding the header for PEP723 compliant tools to work as well as the click library to be able to select what ratefile is being read. I figured if it was ok to use PEP723, then adding another dependency besides pydantic wouldn't be  that big of a deal. Script is executable most easily with [uv](https://docs.astral.sh/uv/) by running `uv run ratefile_read.py`